### PR TITLE
fix: Update Access External Endpoints.ipynb

### DIFF
--- a/Access External Endpoints/Access External Endpoints.ipynb
+++ b/Access External Endpoints/Access External Endpoints.ipynb
@@ -72,7 +72,7 @@
         "CREATE OR REPLACE NETWORK RULE gh_network_rule\n",
         "  MODE = EGRESS\n",
         "  TYPE = HOST_PORT\n",
-        "  VALUE_LIST = ('raw.githubusercontent.com', 'githubusercontent.com', 'github.com');\n",
+        "  VALUE_LIST = ('raw.githubusercontent.com', 'github.com');\n",
         "\n",
         "CREATE OR REPLACE EXTERNAL ACCESS INTEGRATION gh_access_integration\n",
         "  ALLOWED_NETWORK_RULES = (gh_network_rule)\n",


### PR DESCRIPTION
Vanilla `githubusercontent.com` is a non-existent reference; this command fails until it is removed.

See: https://mxtoolbox.com/SuperTool.aspx?action=a%3agithubusercontent.com&run=toolpage