### PR TITLE
Add 'in Workspaces' to notebook title

### DIFF
--- a/getting-started-with-snowflake-notebooks-in-workspaces-eda-ml-pipeline/getting-started-with-snowflake-notebooks-in-workspaces-eda-ml-pipeline.ipynb
+++ b/getting-started-with-snowflake-notebooks-in-workspaces-eda-ml-pipeline/getting-started-with-snowflake-notebooks-in-workspaces-eda-ml-pipeline.ipynb
@@ -8,7 +8,7 @@
         "collapsed": false
       },
       "source": [
-        "# Getting Started with Snowflake Notebooks: Build an EDA and ML Pipeline\n",
+        "# Getting Started with Snowflake Notebooks in Workspaces: Build an EDA and ML Pipeline\n",
         "\n",
         "<div style=\"background: linear-gradient(135deg, #29B5E8, #1A73E8); padding: 40px 50px; border-radius: 12px; color: white;\">\n",
         "  <p style=\"margin: 8px 0 0 0; opacity: 0.9;\">\n",


### PR DESCRIPTION
## Summary
- Updates the H1 title in cell 0 from "Getting Started with Snowflake Notebooks: Build an EDA and ML Pipeline" to "Getting Started with Snowflake Notebooks in Workspaces: Build an EDA and ML Pipeline" to match the renamed folder, notebook filename, and sfquickstarts guide title.

## Test plan
- [ ] Verify notebook title cell renders correctly in Snowflake Notebooks